### PR TITLE
amount:  create and return integer values

### DIFF
--- a/amount.go
+++ b/amount.go
@@ -82,7 +82,7 @@ func NewAmount(n, currencyCode string) (Amount, error) {
 // NewAmountFromBigInt creates a new Amount from a big.Int and a currency code.
 func NewAmountFromBigInt(n *big.Int, currencyCode string) (Amount, error) {
 	if n == nil {
-		return Amount{}, InvalidNumberError{"NewAmountFromBigInt", fmt.Sprint(n)}
+		return Amount{}, InvalidNumberError{"NewAmountFromBigInt", "nil"}
 	}
 	d, ok := GetDigits(currencyCode)
 	if !ok {
@@ -95,7 +95,13 @@ func NewAmountFromBigInt(n *big.Int, currencyCode string) (Amount, error) {
 
 // NewAmountFromInt64 creates a new Amount from an int64 and a currency code.
 func NewAmountFromInt64(n int64, currencyCode string) (Amount, error) {
-	return NewAmountFromBigInt(big.NewInt(n), currencyCode)
+	d, ok := GetDigits(currencyCode)
+	if !ok {
+		return Amount{}, InvalidCurrencyCodeError{"NewAmountFromInt64", currencyCode}
+	}
+	number := apd.New(n, -int32(d))
+
+	return Amount{number, currencyCode}, nil
 }
 
 // Number returns the number as a numeric string.


### PR DESCRIPTION
Enable handling of 64-bit integer and big integer amount values in
minor units.  These types are seen in financial and banking APIs to
avoid the possibility of invalid amounts when dealing with multiple
currencies that have varying decimal handling.

Related to #5 (implementation can be done separately with these changes in place)