### PR TITLE
Fix Amount.RoundTo concurrency issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           ${{ runner.os }}-build-
 
     - name: Test
-      run: go test -v -coverprofile=profile.cov ./...
+      run: go test -v -race -coverprofile=profile.cov ./...
 
     - name: Send coverage
       uses: shogo82148/actions-goveralls@v1

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,6 +1,7 @@
 package currency_test
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -117,4 +118,27 @@ func BenchmarkAmount_Cmp(b *testing.B) {
 		z, _ = x.Cmp(y)
 	}
 	cmpResult = z
+}
+
+func BenchmarkAmount_RoundTo(b *testing.B) {
+	x, _ := currency.NewAmount("34.9876", "USD")
+
+	roundingModes := []currency.RoundingMode{
+		currency.RoundHalfUp,
+		currency.RoundHalfDown,
+		currency.RoundUp,
+		currency.RoundDown,
+	}
+
+	for i := range roundingModes {
+		roundingMode := roundingModes[i]
+
+		b.Run(fmt.Sprintf("rounding_mode_%d", roundingMode), func(b *testing.B) {
+			var z currency.Amount
+			for n := 0; n < b.N; n++ {
+				z = x.RoundTo(2, roundingMode)
+			}
+			result = z
+		})
+	}
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -130,9 +130,7 @@ func BenchmarkAmount_RoundTo(b *testing.B) {
 		currency.RoundDown,
 	}
 
-	for i := range roundingModes {
-		roundingMode := roundingModes[i]
-
+	for _, roundingMode := range roundingModes {
 		b.Run(fmt.Sprintf("rounding_mode_%d", roundingMode), func(b *testing.B) {
 			var z currency.Amount
 			for n := 0; n < b.N; n++ {


### PR DESCRIPTION
### Bug description
`decimalContext` function returns globals which shouldn't be modified concurrently. `Amount.RoundTo` modifies the returned context's `Rounding` property which causes data race condition when `Amount.RoundTo` is called concurrently anywhere. 

### My proposition
Copy the context just in `Amount.RoundTo` method to make it safe for concurrent writes. In all other methods where the `decimalContext` is used it can be left as-is since no write operations are performed there.

I considered also an option with not using globals at all and returning a copy every time from the `decimalContext` func, but I'll leave it up to you to decide if this optimization is needed.