### PR TITLE
Feature/update and deprecate

### DIFF
--- a/currency.go
+++ b/currency.go
@@ -4,7 +4,9 @@
 // Package currency handles currency amounts, provides currency information and formatting.
 package currency
 
-import "sort"
+import (
+	"slices"
+)
 
 // DefaultDigits is a placeholder for each currency's number of fraction digits.
 const DefaultDigits uint8 = 255
@@ -115,16 +117,12 @@ func contains(a []string, x string) bool {
 	n := len(a)
 	if n < 10 {
 		// Linear search is faster with a small number of elements.
-		for _, v := range a {
-			if v == x {
-				return true
-			}
-		}
+		return slices.Contains(a, x)
 	} else {
 		// Binary search is faster with a large number of elements.
-		i := sort.SearchStrings(a, x)
-		if i < n && a[i] == x {
-			return true
+		_, result := slices.BinarySearch(a, x)
+		if result {
+			return result
 		}
 	}
 	return false

--- a/currency.go
+++ b/currency.go
@@ -4,9 +4,7 @@
 // Package currency handles currency amounts, provides currency information and formatting.
 package currency
 
-import (
-	"slices"
-)
+import "slices"
 
 // DefaultDigits is a placeholder for each currency's number of fraction digits.
 const DefaultDigits uint8 = 255

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/bojanz/currency
 
-go 1.17
+go 1.21
 
 require github.com/cockroachdb/apd/v3 v3.2.1


### PR DESCRIPTION
They recently added a slices package to 1.21, this is to allow for a minor deprecation of "contains" function within currency.go.
Functionality remains the same but is now handled by the standard slices package.

Random context: This repo appeared as a recommendation on GitHub so I thought I would contribute to it while i'm on a long-haul flight.