### PR TITLE
Use apd primitives for faster comparisons

### DIFF
--- a/amount.go
+++ b/amount.go
@@ -14,6 +14,8 @@ import (
 	"github.com/cockroachdb/apd/v3"
 )
 
+var zeroDecimal = apd.New(0, 0)
+
 // RoundingMode determines how the amount will be rounded.
 type RoundingMode uint8
 
@@ -263,20 +265,17 @@ func (a Amount) Equal(b Amount) bool {
 
 // IsPositive returns whether a is positive.
 func (a Amount) IsPositive() bool {
-	zero := apd.New(0, 0)
-	return a.number.Cmp(zero) == 1
+	return a.number.Cmp(zeroDecimal) == 1
 }
 
 // IsNegative returns whether a is negative.
 func (a Amount) IsNegative() bool {
-	zero := apd.New(0, 0)
-	return a.number.Cmp(zero) == -1
+	return a.number.Cmp(zeroDecimal) == -1
 }
 
 // IsZero returns whether a is zero.
 func (a Amount) IsZero() bool {
-	zero := apd.New(0, 0)
-	return a.number.Cmp(zero) == 0
+	return a.number.Cmp(zeroDecimal) == 0
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.

--- a/amount.go
+++ b/amount.go
@@ -14,8 +14,6 @@ import (
 	"github.com/cockroachdb/apd/v3"
 )
 
-var zeroDecimal = apd.New(0, 0)
-
 // RoundingMode determines how the amount will be rounded.
 type RoundingMode uint8
 
@@ -265,17 +263,17 @@ func (a Amount) Equal(b Amount) bool {
 
 // IsPositive returns whether a is positive.
 func (a Amount) IsPositive() bool {
-	return a.number.Cmp(zeroDecimal) == 1
+	return a.number.Sign() == 1
 }
 
 // IsNegative returns whether a is negative.
 func (a Amount) IsNegative() bool {
-	return a.number.Cmp(zeroDecimal) == -1
+	return a.number.Sign() == -1
 }
 
 // IsZero returns whether a is zero.
 func (a Amount) IsZero() bool {
-	return a.number.Cmp(zeroDecimal) == 0
+	return a.number.IsZero()
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.
@@ -393,6 +391,13 @@ func (a *Amount) Scan(src any) error {
 var (
 	decimalContextPrecision19 = apd.BaseContext.WithPrecision(19)
 	decimalContextPrecision39 = apd.BaseContext.WithPrecision(39)
+
+	roundersByMode = map[RoundingMode]apd.Rounder{
+		RoundHalfDown: apd.RoundHalfDown,
+		RoundUp:       apd.RoundUp,
+		RoundDown:     apd.RoundDown,
+		RoundHalfEven: apd.RoundHalfEven,
+	}
 )
 
 // decimalContext returns the decimal context to use for a calculation.
@@ -415,14 +420,8 @@ func roundingContext(decimal *apd.Decimal, mode RoundingMode) *apd.Context {
 		return decimalContext(decimal)
 	}
 
-	extModes := map[RoundingMode]apd.Rounder{
-		RoundHalfDown: apd.RoundHalfDown,
-		RoundUp:       apd.RoundUp,
-		RoundDown:     apd.RoundDown,
-		RoundHalfEven: apd.RoundHalfEven,
-	}
 	ctx := *decimalContext(decimal)
-	ctx.Rounding = extModes[mode]
+	ctx.Rounding = roundersByMode[mode]
 
 	return &ctx
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -10,6 +10,7 @@ import (
 
 var result currency.Amount
 var cmpResult int
+var boolResult bool
 
 func BenchmarkNewAmount(b *testing.B) {
 	var z currency.Amount
@@ -138,4 +139,34 @@ func BenchmarkAmount_Cmp(b *testing.B) {
 		z, _ = x.Cmp(y)
 	}
 	cmpResult = z
+}
+
+func BenchmarkAmount_IsPositive(b *testing.B) {
+	x, _ := currency.NewAmount("34.99", "USD")
+
+	var v bool
+	for n := 0; n < b.N; n++ {
+		v = x.IsPositive()
+	}
+	boolResult = v
+}
+
+func BenchmarkAmount_IsNegative(b *testing.B) {
+	x, _ := currency.NewAmount("-12.00", "USD")
+
+	var v bool
+	for n := 0; n < b.N; n++ {
+		v = x.IsNegative()
+	}
+	boolResult = v
+}
+
+func BenchmarkAmount_IsZero(b *testing.B) {
+	x, _ := currency.NewAmount("0.00", "USD")
+
+	var v bool
+	for n := 0; n < b.N; n++ {
+		v = x.IsZero()
+	}
+	boolResult = v
 }


### PR DESCRIPTION
before:

```
$ go test -bench='BenchmarkAmount_Is' -benchmem
goos: darwin
goarch: arm64
pkg: github.com/bojanz/currency
cpu: Apple M2 Max
BenchmarkAmount_IsPositive-12           187741496                6.244 ns/op           0 B/op          0 allocs/op
BenchmarkAmount_IsNegative-12           191502921                6.224 ns/op           0 B/op          0 allocs/op
BenchmarkAmount_IsZero-12               202620387                5.994 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/bojanz/currency      5.999s
```

after:

```
$ go test -bench='BenchmarkAmount_Is' -benchmem
goos: darwin
goarch: arm64
pkg: github.com/bojanz/currency
cpu: Apple M2 Max
BenchmarkAmount_IsPositive-12           620603521                1.753 ns/op           0 B/op          0 allocs/op
BenchmarkAmount_IsNegative-12           826252094                1.447 ns/op           0 B/op          0 allocs/op
BenchmarkAmount_IsZero-12               916716909                1.332 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/bojanz/currency      4.318s
```
