### PR TITLE
Don't render a minus sign for negatives that round to zero

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -85,9 +85,21 @@ func (f *Formatter) Locale() Locale {
 
 // Format formats a currency amount.
 func (f *Formatter) Format(amount Amount) string {
+	// Round to the display precision up front, so the sign and pattern match
+	// the digits that are actually shown. Otherwise an amount that rounds to
+	// zero (e.g. "-0.001" with two fraction digits) would still be treated as
+	// negative, producing a spurious minus sign ("-$0.00" instead of "$0.00").
+	maxDigits := f.MaxDigits
+	if maxDigits == DefaultDigits {
+		maxDigits, _ = GetDigits(amount.CurrencyCode())
+	}
+	amount = amount.RoundTo(maxDigits, f.RoundingMode)
 	pattern := f.getPattern(amount)
-	if amount.IsNegative() {
-		// The minus sign will be provided by the pattern.
+	if amount.number.Negative {
+		// Drop the negative sign from the number itself; the minus sign (for a
+		// genuinely negative amount) is provided by the pattern. This also
+		// strips the leftover sign from a negative value that rounded to zero,
+		// which would otherwise leak a "-" into the formatted digits.
 		amount, _ = amount.Mul("-1")
 	}
 	formattedNumber := f.formatNumber(amount)

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -228,6 +228,44 @@ func TestFormatter_Digits(t *testing.T) {
 	}
 }
 
+func TestFormatter_NegativeRoundingToZero(t *testing.T) {
+	// A negative amount that rounds to zero must not keep its minus sign,
+	// neither as a leading "-" nor as accounting-style parentheses.
+	tests := []struct {
+		number          string
+		currencyCode    string
+		localeID        string
+		maxDigits       uint8
+		accountingStyle bool
+		want            string
+	}{
+		// Standard style: "-$0.00" was produced before the fix.
+		{"-0.001", "USD", "en", 2, false, "$0.00"},
+		{"-0.004", "USD", "en", 2, false, "$0.00"},
+		// JPY has 0 fraction digits, so "-0.4" rounds to 0 ("¥-0" before the fix).
+		{"-0.4", "JPY", "en", currency.DefaultDigits, false, "¥0"},
+		// Accounting style: "($0.00)" was produced before the fix.
+		{"-0.004", "USD", "en", 2, true, "$0.00"},
+		// A negative amount that does NOT round to zero keeps its sign.
+		{"-0.006", "USD", "en", 2, false, "-$0.01"},
+		{"-0.006", "USD", "en", 2, true, "($0.01)"},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			amount, _ := currency.NewAmount(tt.number, tt.currencyCode)
+			locale := currency.NewLocale(tt.localeID)
+			formatter := currency.NewFormatter(locale)
+			formatter.MaxDigits = tt.maxDigits
+			formatter.AccountingStyle = tt.accountingStyle
+			got := formatter.Format(amount)
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatter_RoundingMode(t *testing.T) {
 	tests := []struct {
 		number       string


### PR DESCRIPTION
`Formatter.Format` adds a spurious `-` to a negative value that rounds to zero (e.g. `-0.001` → `-$0.00`, `-0.4` JPY → `¥-0`), because the apd negative-zero is not normalized. The ~12-line fix drops the sign when the rounded magnitude is zero. Verified both ways.