### PR TITLE
Do not duplicate a currency code when re-registering

### DIFF
--- a/currency.go
+++ b/currency.go
@@ -155,11 +155,14 @@ func Register(currencyCode string, d Definition) {
 		return
 	}
 
+	if _, ok := currencies[currencyCode]; !ok {
+		// Overriding an existing currency must not duplicate its code.
+		currencyCodes = append(currencyCodes, currencyCode)
+	}
 	currencies[currencyCode] = currencyInfo{
 		numericCode: d.NumericCode,
 		digits:      d.Digits,
 	}
-	currencyCodes = append(currencyCodes, currencyCode)
 
 	if d.DefaultSymbol != "" {
 		currencySymbols[currencyCode] = []symbolInfo{

--- a/currency_test.go
+++ b/currency_test.go
@@ -236,4 +236,14 @@ func Test_Register_OverrideExisting(t *testing.T) {
 	if symbol != "$$" {
 		t.Errorf("got %v, want $$", symbol)
 	}
+
+	n := 0
+	for _, currencyCode := range currency.GetCurrencyCodes() {
+		if currencyCode == "CAD" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("got %v occurrences of CAD in GetCurrencyCodes(), want 1", n)
+	}
 }


### PR DESCRIPTION
`Register` writes to the `currencies` map, which overwrites, but appends to `currencyCodes`
unconditionally. So a currency code can end up in `GetCurrencyCodes()` more than once.

The doc comment names two uses:

> This can be a non-ISO currency such as BTC, or **an existing currency for which we want to
> override the predefined data**.

The second one duplicates. Running against the current registry:

```
len before = 165   CAD count = 1
Register("CAD", ...)   // override, twice, as the README's use case describes
len after  = 167   CAD count = 3   tail = [ZWG CAD CAD]
```

It is not limited to ISO currencies either - registering a genuinely new one twice does the
same:

```
Register("BTC", ...) x2   ->  len = 169, BTC count = 2
```

`GetCurrencyCodes()` returns the backing slice directly, so anything built from it - a select
list, a validation set, a fixture loop - carries the duplicate. `IsValid` and `GetNumericCode`
stay correct because they read the map, which is why this went unnoticed.

### The change

Append only when the code is not already known, using the same map lookup `IsValid` uses.
Ordering of the existing entries is untouched.

### Test

`Test_Register_OverrideExisting` already registers `CAD` twice and asserts on `IsValid`,
`GetNumericCode`, `GetDigits` and `GetSymbol` - everything except the code list. One assertion
added at the end of that test, after both `Register` calls.

Reverting only the `currency.go` change:

```
--- FAIL: Test_Register_OverrideExisting
    currency_test.go:247: got 3 occurrences of CAD in GetCurrencyCodes(), want 1
```

`go test ./...` passes with the change, `gofmt -l` and `go vet` clean.

---

Disclosure: found and prepared with AI assistance (Claude). Every number above is from a run on
this branch.
